### PR TITLE
AT command for transparent should be ATO\r

### DIFF
--- a/arduino/sketchbook/libraries/sim800/sim800.cpp
+++ b/arduino/sketchbook/libraries/sim800/sim800.cpp
@@ -979,7 +979,7 @@ bool sim800Client::transparent()
   char buf[BUF_LENGTH];
 
   IF_SDEBUG(Serial.println(F("#sim800:going to transparent mode")));
-  return ATcommand("ATO0", buf, "CONNECT", ERRORSTR, 5000);
+  return ATcommand("O", buf, "CONNECT", ERRORSTR, 5000);
 
 }
 


### PR DESCRIPTION
The `ATCommand` function will add AT at the start. So in transparent function we should remove `AT`.

The command is ATO .. ATO0 wont work .. at least in my case