### PR TITLE
Add files via upload

### DIFF
--- a/arduino/sketchbook/rmap/i2c-rain/config.h
+++ b/arduino/sketchbook/rmap/i2c-rain/config.h
@@ -14,7 +14,9 @@
 // millisec
 
 // with 200 the maximum rain rate is 1 Kg/m^2/s with a  tipping bucket rain gauge with .2 Kg/m^2 tips
-#define DEBOUNCINGTIME 200
+#define DEBOUNCINGTIME 1000
+#define MIN_COMMUTATION_TIME 20
+#define MAX_COMMUTATION_TIME 500
 
 // temporary patch for microduino; see http://forum.microduino.cc/topic/91/digitalpintointerrupt-was-not-declared-in-this-scope
 #define digitalPinToInterrupt(p) ((p) == 2 ? 0 : ((p) == 3 ? 1 : ((p) >= 18 && (p) <= 21 ? 23 - (p) : NOT_AN_INTERRUPT)))

--- a/arduino/sketchbook/rmap/i2c-rain/i2c-rain.ino
+++ b/arduino/sketchbook/rmap/i2c-rain/i2c-rain.ino
@@ -122,19 +122,27 @@ static bool stop =false;
 volatile unsigned int count;
 volatile unsigned long antirimb=0;
 
+volatile unsigned long fallingtime=0;
+volatile unsigned long risingtime=0;
+
 boolean forcedefault=false;
 
-void countadd()
+void change()
 {
   unsigned long now=millis();
-
-  if ((now-antirimb) > DEBOUNCINGTIME){
-    count ++;
-    antirimb=now;
-    //IF_SDEBUG(Serial.print(F("count: ")));IF_SDEBUG(Serial.println(count));
+  
+  if (digitalRead(RAINGAUGEPIN)==LOW) fallingtime=now;
+  else risingtime=now; 
+  if(risingtime>fallingtime){
+  if (((risingtime-fallingtime) > MIN_COMMUTATION_TIME)&&((risingtime-fallingtime) < MAX_COMMUTATION_TIME)){
+      if ((now-antirimb) > DEBOUNCINGTIME){
+        count ++;
+        //digitalWrite(LEDPIN,count % 2);
+        antirimb=now;
+      }
+    } 
   }
 }
-
 
 //////////////////////////////////////////////////////////////////////////////////////
 // I2C handlers
@@ -328,8 +336,8 @@ void setup() {
   // initialize counter and fuffer for read
   count=0;
   i2c_dataset2->rain.tips=count;
-
-  attachInterrupt(digitalPinToInterrupt(RAINGAUGEPIN), countadd, RISING);
+  IF_SDEBUG(Serial.print(F("interrupt...init")));
+  attachInterrupt(digitalPinToInterrupt(RAINGAUGEPIN),change  , CHANGE);
   //detachInterrupt(digitalPinToInterrupt(RAINGAUGEPIN));
 
   IF_SDEBUG(Serial.println(F("end setup")));
@@ -393,7 +401,10 @@ void loop() {
 
 
 
-  //IF_SDEBUG(Serial.print(F("count: ")));IF_SDEBUG(Serial.println(count));
+  // IF_SDEBUG(Serial.print(F("count: ")));IF_SDEBUG(Serial.println(count));
+  // IF_SDEBUG(Serial.print(F("rising: ")));IF_SDEBUG(Serial.println(risingtime));
+  //if(risingtime>fallingtime) IF_SDEBUG(Serial.print(F("time: ")));IF_SDEBUG(Serial.println(risingtime-fallingtime));
+
 
   if (oneshot) {
 


### PR DESCRIPTION
Modifica della gestione della routine di interrupt per il pluviometro. 
Si considera una basculata valida se il segnale stà basso per un intervallo compreso tra MIN_COMMUTATION_TIME  e MAX_COMMUTATION_TIME 

La bascula del pluviometro ETG in laboratorio oscilla in prova dinamica tra 95ms e 107ms.


