### PR TITLE
Etgavalgimigli master

### DIFF
--- a/arduino/sketchbook/rmap/i2c-rain/config.h
+++ b/arduino/sketchbook/rmap/i2c-rain/config.h
@@ -14,9 +14,14 @@
 // millisec
 
 // with 200 the maximum rain rate is 1 Kg/m^2/s with a  tipping bucket rain gauge with .2 Kg/m^2 tips
-#define DEBOUNCINGTIME 1000
+#define DEBOUNCINGTIME 200
+
+// For ETG raingauge
+//#define ETGRAINGAUGE
+#ifdef ETGRAINGAUGE
 #define MIN_COMMUTATION_TIME 20
-#define MAX_COMMUTATION_TIME 500
+#define MAX_COMMUTATION_TIME 100
+#endif
 
 // temporary patch for microduino; see http://forum.microduino.cc/topic/91/digitalpintointerrupt-was-not-declared-in-this-scope
 #define digitalPinToInterrupt(p) ((p) == 2 ? 0 : ((p) == 3 ? 1 : ((p) >= 18 && (p) <= 21 ? 23 - (p) : NOT_AN_INTERRUPT)))


### PR DESCRIPTION
questo il commento  alla proposta di modifica di ETG:
"Modifica della gestione della routine di interrupt per il pluviometro.
Si considera una basculata valida se il segnale stà basso per un intervallo compreso tra MIN_COMMUTATION_TIME e MAX_COMMUTATION_TIME
La bascula del pluviometro ETG in laboratorio oscilla in prova dinamica tra 95ms e 107ms."

Implementata come opzione nel config file e modificati i tempi per poter registrare anche precipitazioni intense.
