### PR TITLE
Changed data.json response content type

### DIFF
--- a/arduino/sketchbook/stima_v2/stimawifi/stimawifi.ino
+++ b/arduino/sketchbook/stima_v2/stimawifi/stimawifi.ino
@@ -215,7 +215,7 @@ void handle_Data() {
 void handle_Json() {
   webserver.sendHeader("Access-Control-Allow-Origin", "*", true);
   webserver.sendHeader("Access-Control-Allow-Methods", "*", true);
-  webserver.send(200, "text/html", Json()); 
+  webserver.send(200, "application/json", Json()); 
 }
 
 void handle_NotFound(){

--- a/platformio/stima_v2/stimawifi/src/stimawifi.ino
+++ b/platformio/stima_v2/stimawifi/src/stimawifi.ino
@@ -218,7 +218,7 @@ void handle_Data() {
 void handle_Json() {
   webserver.sendHeader("Access-Control-Allow-Origin", "*", true);
   webserver.sendHeader("Access-Control-Allow-Methods", "*", true);
-  webserver.send(200, "text/html", Json()); 
+  webserver.send(200, "application/json", Json()); 
 }
 
 void handle_NotFound(){


### PR DESCRIPTION
Previously the content type returned was text/html. Too generic in not wrong.
Changed the content type to application/json to better reflect che response content
in case of an http request hit the url /data.json

close issue #333